### PR TITLE
Default item durability from materials

### DIFF
--- a/item-integrity-module/module.json
+++ b/item-integrity-module/module.json
@@ -8,7 +8,7 @@
     "minimum": "13",
     "verified": "13"
   },
-  "scripts": [
+  "esmodules": [
     "scripts/main.js"
   ],
   "authors": [

--- a/item-integrity-module/scripts/main.js
+++ b/item-integrity-module/scripts/main.js
@@ -1,1 +1,34 @@
-console.log('PF2e Item Integrity module initialized.');
+import { getMaterialValues } from './materials';
+function ensureDurability(item) {
+    if (!item?.isOfType?.('physical'))
+        return;
+    const updates = {};
+    // Derive material-based defaults
+    const materialType = item.system?.material?.type ?? null;
+    const materialValues = getMaterialValues(materialType);
+    const hp = item.system?.hp;
+    if (!hp || hp.max == null) {
+        updates['system.hp'] = {
+            value: materialValues.hp,
+            max: materialValues.hp,
+            brokenThreshold: Math.floor(materialValues.hp / 2),
+        };
+    }
+    if (item.system?.hardness == null) {
+        updates['system.hardness'] = materialValues.hardness;
+    }
+    if (Object.keys(updates).length > 0) {
+        item.update(updates);
+    }
+}
+Hooks.once('ready', () => {
+    console.log('PF2e Item Integrity module initialized.');
+    for (const item of game.items.contents ?? []) {
+        ensureDurability(item);
+    }
+    for (const actor of game.actors.contents ?? []) {
+        for (const item of actor.items.contents ?? []) {
+            ensureDurability(item);
+        }
+    }
+});

--- a/item-integrity-module/scripts/main.ts
+++ b/item-integrity-module/scripts/main.ts
@@ -1,1 +1,45 @@
-console.log('PF2e Item Integrity module initialized.');
+import { getMaterialValues } from './materials';
+
+declare const Hooks: any;
+declare const game: any;
+
+function ensureDurability(item: any) {
+  if (!item?.isOfType?.('physical')) return;
+
+  const updates: any = {};
+
+  // Derive material-based defaults
+  const materialType = item.system?.material?.type ?? null;
+  const materialValues = getMaterialValues(materialType);
+
+  const hp = item.system?.hp;
+  if (!hp || hp.max == null) {
+    updates['system.hp'] = {
+      value: materialValues.hp,
+      max: materialValues.hp,
+      brokenThreshold: Math.floor(materialValues.hp / 2),
+    };
+  }
+
+  if (item.system?.hardness == null) {
+    updates['system.hardness'] = materialValues.hardness;
+  }
+
+  if (Object.keys(updates).length > 0) {
+    item.update(updates);
+  }
+}
+
+Hooks.once('ready', () => {
+  console.log('PF2e Item Integrity module initialized.');
+
+  for (const item of game.items.contents ?? []) {
+    ensureDurability(item);
+  }
+
+  for (const actor of game.actors.contents ?? []) {
+    for (const item of actor.items.contents ?? []) {
+      ensureDurability(item);
+    }
+  }
+});

--- a/item-integrity-module/scripts/materials.js
+++ b/item-integrity-module/scripts/materials.js
@@ -1,0 +1,12 @@
+const MATERIALS = {
+    wood: { hp: 20, hardness: 5 },
+    stone: { hp: 40, hardness: 8 },
+    steel: { hp: 60, hardness: 9 },
+};
+/**
+ * Retrieve durability values for a given material type.
+ * Returns 0 hardness and hp if the material is unknown.
+ */
+export function getMaterialValues(type) {
+    return MATERIALS[type ?? ""] ?? { hp: 0, hardness: 0 };
+}

--- a/item-integrity-module/scripts/materials.ts
+++ b/item-integrity-module/scripts/materials.ts
@@ -1,0 +1,18 @@
+export interface MaterialValues {
+  hp: number;
+  hardness: number;
+}
+
+const MATERIALS: Record<string, MaterialValues> = {
+  wood: { hp: 20, hardness: 5 },
+  stone: { hp: 40, hardness: 8 },
+  steel: { hp: 60, hardness: 9 },
+};
+
+/**
+ * Retrieve durability values for a given material type.
+ * Returns 0 hardness and hp if the material is unknown.
+ */
+export function getMaterialValues(type: string | null | undefined): MaterialValues {
+  return MATERIALS[type ?? ""] ?? { hp: 0, hardness: 0 };
+}


### PR DESCRIPTION
## Summary
- set up module to iterate over physical items on ready and apply missing hp/hardness using material defaults
- add simple materials table used for deriving hp and hardness
- switch module manifest to load main script as esmodule

## Testing
- `npx tsc scripts/main.ts scripts/materials.ts --target ES2020 --module ES6 --strict`


------
https://chatgpt.com/codex/tasks/task_e_68c17bde2bd4832795dea3921efc6eda