### PR TITLE
Add durability info to physical item sheets

### DIFF
--- a/item-integrity-module/scripts/main.js
+++ b/item-integrity-module/scripts/main.js
@@ -1,4 +1,5 @@
 import { getMaterialValues } from './materials';
+import { ItemIntegritySheetPF2e } from './sheet';
 function ensureDurability(item) {
     if (!item?.isOfType?.('physical'))
         return;
@@ -21,6 +22,12 @@ function ensureDurability(item) {
         item.update(updates);
     }
 }
+Hooks.once('init', () => {
+    Items.registerSheet('pf2e', ItemIntegritySheetPF2e, {
+        types: ['armor', 'consumable', 'equipment', 'treasure', 'weapon', 'backpack'],
+        makeDefault: true,
+    });
+});
 Hooks.once('ready', () => {
     console.log('PF2e Item Integrity module initialized.');
     for (const item of game.items.contents ?? []) {

--- a/item-integrity-module/scripts/main.ts
+++ b/item-integrity-module/scripts/main.ts
@@ -1,7 +1,9 @@
 import { getMaterialValues } from './materials';
+import { ItemIntegritySheetPF2e } from './sheet';
 
 declare const Hooks: any;
 declare const game: any;
+declare const Items: any;
 
 function ensureDurability(item: any) {
   if (!item?.isOfType?.('physical')) return;
@@ -29,6 +31,13 @@ function ensureDurability(item: any) {
     item.update(updates);
   }
 }
+
+Hooks.once('init', () => {
+  Items.registerSheet('pf2e', ItemIntegritySheetPF2e, {
+    types: ['armor', 'consumable', 'equipment', 'treasure', 'weapon', 'backpack'],
+    makeDefault: true,
+  });
+});
 
 Hooks.once('ready', () => {
   console.log('PF2e Item Integrity module initialized.');

--- a/item-integrity-module/scripts/sheet.js
+++ b/item-integrity-module/scripts/sheet.js
@@ -1,0 +1,18 @@
+export class ItemIntegritySheetPF2e extends PhysicalItemSheetPF2e {
+    get template() {
+        return super.template;
+    }
+    async getData(options = {}) {
+        const data = await super.getData(options);
+        data.isBroken = this.item.isBroken ?? false;
+        data.isDestroyed = this.item.isDestroyed ?? false;
+        return data;
+    }
+    async _renderInner(data, options) {
+        const html = await super._renderInner(data, options);
+        const inner = await renderTemplate('modules/pf2e-item-integrity/templates/integrity.hbs', data);
+        const element = html instanceof HTMLElement ? html : html[0];
+        element.querySelector('.sheet-content')?.insertAdjacentHTML('beforeend', inner);
+        return html;
+    }
+}

--- a/item-integrity-module/scripts/sheet.ts
+++ b/item-integrity-module/scripts/sheet.ts
@@ -1,0 +1,23 @@
+declare const PhysicalItemSheetPF2e: any;
+declare function renderTemplate(path: string, data: any): Promise<string>;
+
+export class ItemIntegritySheetPF2e extends PhysicalItemSheetPF2e {
+  get template() {
+    return super.template;
+  }
+
+  async getData(options: any = {}) {
+    const data = await super.getData(options);
+    data.isBroken = this.item.isBroken ?? false;
+    data.isDestroyed = this.item.isDestroyed ?? false;
+    return data;
+  }
+
+  async _renderInner(data: any, options: any) {
+    const html = await super._renderInner(data, options);
+    const inner = await renderTemplate('modules/pf2e-item-integrity/templates/integrity.hbs', data);
+    const element = html instanceof HTMLElement ? html : html[0];
+    element.querySelector('.sheet-content')?.insertAdjacentHTML('beforeend', inner);
+    return html;
+  }
+}

--- a/item-integrity-module/templates/integrity.hbs
+++ b/item-integrity-module/templates/integrity.hbs
@@ -1,0 +1,14 @@
+<section class="item-integrity">
+  <h3>Integrity</h3>
+  <ul>
+    <li>HP: {{system.hp.value}} / {{system.hp.max}}</li>
+    <li>Hardness: {{system.hardness}}</li>
+    <li>Status: {{#if isDestroyed}}Destroyed{{else if isBroken}}Broken{{else}}Intact{{/if}}</li>
+    {{#if system.hp.brokenThreshold}}
+      <li>Broken Threshold: {{system.hp.brokenThreshold}}</li>
+    {{/if}}
+    {{#if system.hp.repairStatus}}
+      <li>Repair Status: {{system.hp.repairStatus}}</li>
+    {{/if}}
+  </ul>
+</section>


### PR DESCRIPTION
## Summary
- register a custom physical item sheet displaying integrity stats
- show HP, hardness, and status including broken threshold and repair status

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c17d73839883279cf5d1c56271275e