### PR TITLE
Add item damage application helper

### DIFF
--- a/item-integrity-module/scripts/main.ts
+++ b/item-integrity-module/scripts/main.ts
@@ -4,6 +4,38 @@ import { ItemIntegritySheetPF2e } from './sheet';
 declare const Hooks: any;
 declare const game: any;
 declare const Items: any;
+declare const Roll: any;
+declare const ChatMessage: any;
+
+export async function applyItemDamage(item: any, damage: number | string): Promise<void> {
+  if (!item?.system?.hp) return;
+
+  let rollTotal: number;
+  if (typeof damage === 'string') {
+    const roll = await new Roll(damage).roll({ async: true });
+    rollTotal = roll.total;
+  } else {
+    rollTotal = damage;
+  }
+
+  const hardness = item.system.hardness ?? 0;
+  const applied = Math.max(rollTotal - hardness, 0);
+  const hp = item.system.hp;
+  const newValue = Math.max(hp.value - applied, 0);
+
+  const isDestroyed = newValue <= 0;
+  const isBroken = !isDestroyed && newValue <= (hp.brokenThreshold ?? 0);
+
+  await item.update({
+    'system.hp.value': newValue,
+    'flags.pf2e.broken': isBroken,
+    'flags.pf2e.destroyed': isDestroyed,
+  });
+
+  await ChatMessage.create({
+    content: `${item.name} takes ${applied} damage (Hardness ${hardness}).`,
+  });
+}
 
 function ensureDurability(item: any) {
   if (!item?.isOfType?.('physical')) return;


### PR DESCRIPTION
## Summary
- add applyItemDamage helper to process hardness, track HP, and report damage via chat

## Testing
- `npx tsc scripts/main.ts --target ES2020 --module ES6 --outDir scripts`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68c183c389488327839abd3ac1be0dda