### PR TITLE
Fix missing module extensions in main TS entry

### DIFF
--- a/item-integrity-module/scripts/main.js
+++ b/item-integrity-module/scripts/main.js
@@ -1,5 +1,5 @@
-import { getMaterialValues } from './materials';
-import { ItemIntegritySheetPF2e } from './sheet';
+import { getMaterialValues } from "./materials.js";
+import { ItemIntegritySheetPF2e } from "./sheet.js";
 let pendingItemTarget = null;
 export async function applyItemDamage(item, damage) {
     if (!item?.system?.hp)

--- a/item-integrity-module/scripts/main.ts
+++ b/item-integrity-module/scripts/main.ts
@@ -1,5 +1,5 @@
-import { getMaterialValues } from './materials';
-import { ItemIntegritySheetPF2e } from './sheet';
+import { getMaterialValues } from "./materials.js";
+import { ItemIntegritySheetPF2e } from "./sheet.js";
 
 declare const Hooks: any;
 declare const game: any;


### PR DESCRIPTION
## Summary
- use explicit `.js` extensions in main module imports to prevent 404s

## Testing
- `tsc --project item-integrity-module/tsconfig.json` *(fails: No inputs were found)*
- `tsc item-integrity-module/scripts/main.ts item-integrity-module/scripts/materials.ts item-integrity-module/scripts/sheet.ts --target ES2020 --module ES6 --strict --outDir item-integrity-module/scripts`
- `npx --yes @foundryvtt/foundryvtt@latest` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1baa7c324832785c2009a699fd7c5