### PR TITLE
Store item hit points in module flags

### DIFF
--- a/item-integrity-module/templates/integrity.hbs
+++ b/item-integrity-module/templates/integrity.hbs
@@ -1,14 +1,14 @@
 <section class="item-integrity">
   <h3>Integrity</h3>
   <ul>
-    <li>HP: {{system.hp.value}} / {{system.hp.max}}</li>
+    <li>HP: {{flags.pf2e-item-integrity.hp.value}} / {{flags.pf2e-item-integrity.hp.max}}</li>
     <li>Hardness: {{system.hardness}}</li>
     <li>Status: {{#if isDestroyed}}Destroyed{{else if isBroken}}Broken{{else}}Intact{{/if}}</li>
-    {{#if system.hp.brokenThreshold}}
-      <li>Broken Threshold: {{system.hp.brokenThreshold}}</li>
+    {{#if flags.pf2e-item-integrity.hp.brokenThreshold}}
+      <li>Broken Threshold: {{flags.pf2e-item-integrity.hp.brokenThreshold}}</li>
     {{/if}}
-    {{#if system.hp.repairStatus}}
-      <li>Repair Status: {{system.hp.repairStatus}}</li>
+    {{#if flags.pf2e-item-integrity.hp.repairStatus}}
+      <li>Repair Status: {{flags.pf2e-item-integrity.hp.repairStatus}}</li>
     {{/if}}
   </ul>
 </section>


### PR DESCRIPTION
## Summary
- Track item HP using pf2e-item-integrity flags instead of system data
- Render integrity template from flag-based HP fields

## Testing
- `tsc item-integrity-module/scripts/main.ts item-integrity-module/scripts/materials.ts item-integrity-module/scripts/sheet.ts --target ES2020 --module ES6 --strict --outDir item-integrity-module/scripts --listEmittedFiles`


------
https://chatgpt.com/codex/tasks/task_e_68c58658376c83279c139d3c8678132d